### PR TITLE
Keep the SecurityContextHolder's Authentication even when access denied

### DIFF
--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -202,9 +202,6 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 	protected void sendStartAuthentication(HttpServletRequest request,
 			HttpServletResponse response, FilterChain chain,
 			AuthenticationException reason) throws ServletException, IOException {
-		// SEC-112: Clear the SecurityContextHolder's Authentication, as the
-		// existing Authentication is no longer considered valid
-		SecurityContextHolder.getContext().setAuthentication(null);
 		requestCache.saveRequest(request, response);
 		logger.debug("Calling Authentication entry point.");
 		authenticationEntryPoint.commence(request, response, reason);


### PR DESCRIPTION
as RememberMeAuthenticationToken and AnonymousAuthenticationToken may
have necessary information for authentication.
Multi factor (multi step) authentication like FIDO-U2F have to use
AnonymousAuthenticationToken's sub-class for representing first factor
(first step) authentication pass


