### PR TITLE
Keep the SecurityContextHolder's Authentication even when access denied

### DIFF
--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolver.java
@@ -43,6 +43,9 @@ public interface AuthenticationTrustResolver {
 	 */
 	boolean isAnonymous(Authentication authentication);
 
+
+	boolean isFullyAnonymous(Authentication authentication);
+
 	/**
 	 * Indicates whether the passed <code>Authentication</code> token represents user that
 	 * has been remembered (i.e. not a user that has been fully authenticated).

--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
@@ -34,6 +34,7 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	// ================================================================================================
 
 	private Class<? extends Authentication> anonymousClass = AnonymousAuthenticationToken.class;
+	private Class<? extends Authentication> firstOfMultiFactorClass = FirstOfMultiFactorAuthenticationToken.class;
 	private Class<? extends Authentication> rememberMeClass = RememberMeAuthenticationToken.class;
 
 	// ~ Methods
@@ -43,11 +44,25 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 		return anonymousClass;
 	}
 
+	Class<? extends Authentication> getFirstOfMultiFactorClass() { return firstOfMultiFactorClass; }
+
 	Class<? extends Authentication> getRememberMeClass() {
 		return rememberMeClass;
 	}
 
 	public boolean isAnonymous(Authentication authentication) {
+		if(isFullyAnonymous(authentication)){
+			return true;
+		}
+		if ((firstOfMultiFactorClass == null) || (authentication == null)) {
+			return false;
+		}
+
+		return firstOfMultiFactorClass.isAssignableFrom(authentication.getClass());
+	}
+
+	@Override
+	public boolean isFullyAnonymous(Authentication authentication) {
 		if ((anonymousClass == null) || (authentication == null)) {
 			return false;
 		}
@@ -66,6 +81,8 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	public void setAnonymousClass(Class<? extends Authentication> anonymousClass) {
 		this.anonymousClass = anonymousClass;
 	}
+
+	public void setFirstOfMultiFactorClass(Class<? extends Authentication> firstOfMultiFactorClass) {this.firstOfMultiFactorClass = firstOfMultiFactorClass; }
 
 	public void setRememberMeClass(Class<? extends Authentication> rememberMeClass) {
 		this.rememberMeClass = rememberMeClass;

--- a/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/FirstOfMultiFactorAuthenticationToken.java
@@ -1,0 +1,36 @@
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+public class FirstOfMultiFactorAuthenticationToken extends AbstractAuthenticationToken implements
+	Serializable {
+
+	private Object principal;
+	private Object credentials;
+
+	// ~ Constructors
+	// ===================================================================================================
+	public FirstOfMultiFactorAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(true);
+	}
+
+	// ~ Methods
+	// ========================================================================================================
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return credentials;
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -195,9 +195,6 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 	protected void sendStartAuthentication(HttpServletRequest request,
 			HttpServletResponse response, FilterChain chain,
 			AuthenticationException reason) throws ServletException, IOException {
-		// SEC-112: Clear the SecurityContextHolder's Authentication, as the
-		// existing Authentication is no longer considered valid
-		SecurityContextHolder.getContext().setAuthentication(null);
 		requestCache.saveRequest(request, response);
 		logger.debug("Calling Authentication entry point.");
 		authenticationEntryPoint.commence(request, response, reason);

--- a/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
@@ -332,7 +332,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 		/**
 		 * Stores the supplied security context in the session (if available) and if it
 		 * has changed since it was set at the start of the request. If the
-		 * AuthenticationTrustResolver identifies the current user as anonymous, then the
+		 * AuthenticationTrustResolver identifies the current user as fully anonymous, then the
 		 * context will not be stored.
 		 *
 		 * @param context the context object obtained from the SecurityContextHolder after
@@ -347,7 +347,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 			HttpSession httpSession = request.getSession(false);
 
 			// See SEC-776
-			if (authentication == null || trustResolver.isAnonymous(authentication)) {
+			if (authentication == null || trustResolver.isFullyAnonymous(authentication)) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("SecurityContext is empty or contents are anonymous - context will not be stored in HttpSession.");
 				}

--- a/web/src/test/java/org/springframework/security/web/context/HttpSessionSecurityContextRepositoryTests.java
+++ b/web/src/test/java/org/springframework/security/web/context/HttpSessionSecurityContextRepositoryTests.java
@@ -592,7 +592,7 @@ public class HttpSessionSecurityContextRepositoryTests {
 
 		repo.saveContext(contextToSave, holder.getRequest(), holder.getResponse());
 
-		verify(trustResolver).isAnonymous(contextToSave.getAuthentication());
+		verify(trustResolver).isFullyAnonymous(contextToSave.getAuthentication());
 	}
 
 	@Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
as RememberMeAuthenticationToken and AnonymousAuthenticationToken may
have necessary information for authentication.
Multi factor (multi step) authentication like FIDO-U2F have to use
AnonymousAuthenticationToken's sub-class for representing first factor
(first step) authentication pass

<!--
Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->
