### PR TITLE
[WIP][Review]Add MultifactorAuthenticationToken

### DIFF
--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurer.java
@@ -26,35 +26,35 @@ import org.springframework.security.config.annotation.authentication.ProviderMan
  * @param <B> the type of the {@link SecurityBuilder}
  */
 public class MultiFactorAuthenticationProviderConfigurer<B extends ProviderManagerBuilder<B>>
-        extends SecurityConfigurerAdapter<AuthenticationManager, B> {
+		extends SecurityConfigurerAdapter<AuthenticationManager, B> {
 
-    //~ Instance fields
-    // ================================================================================================
-    private AuthenticationProvider authenticationProvider;
-    private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+	//~ Instance fields
+	// ================================================================================================
+	private AuthenticationProvider authenticationProvider;
+	private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
 
-    /**
-     * Constructor
-     * @param authenticationProvider {@link AuthenticationProvider} to be delegated
-     */
-    public MultiFactorAuthenticationProviderConfigurer(AuthenticationProvider authenticationProvider) {
-        this.authenticationProvider = authenticationProvider;
-    }
+	/**
+	 * Constructor
+	 * @param authenticationProvider {@link AuthenticationProvider} to be delegated
+	 */
+	public MultiFactorAuthenticationProviderConfigurer(AuthenticationProvider authenticationProvider) {
+		this.authenticationProvider = authenticationProvider;
+	}
 
 
 	public static MultiFactorAuthenticationProviderConfigurer multiFactorAuthenticationProvider(AuthenticationProvider authenticationProvider){
 		return new MultiFactorAuthenticationProviderConfigurer(authenticationProvider);
 	}
 
-    @Override
-    public void configure(B builder) {
-        MultiFactorAuthenticationProvider multiFactorAuthenticationProvider = new MultiFactorAuthenticationProvider(authenticationProvider, mfaTokenEvaluator);
-        multiFactorAuthenticationProvider = postProcess(multiFactorAuthenticationProvider);
-        builder.authenticationProvider(multiFactorAuthenticationProvider);
-    }
+	@Override
+	public void configure(B builder) {
+		MultiFactorAuthenticationProvider multiFactorAuthenticationProvider = new MultiFactorAuthenticationProvider(authenticationProvider, mfaTokenEvaluator);
+		multiFactorAuthenticationProvider = postProcess(multiFactorAuthenticationProvider);
+		builder.authenticationProvider(multiFactorAuthenticationProvider);
+	}
 
-    public MultiFactorAuthenticationProviderConfigurer<B> mfaTokenEvaluator(MFATokenEvaluator mfaTokenEvaluator) {
-        this.mfaTokenEvaluator = mfaTokenEvaluator;
-        return this;
-    }
+	public MultiFactorAuthenticationProviderConfigurer<B> mfaTokenEvaluator(MFATokenEvaluator mfaTokenEvaluator) {
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
+		return this;
+	}
 }

--- a/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.config.annotation.authentication.configurers.mfa;
+
+import org.springframework.security.authentication.*;
+import org.springframework.security.config.annotation.SecurityBuilder;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.authentication.ProviderManagerBuilder;
+
+/**
+ *
+ * @param <B> the type of the {@link SecurityBuilder}
+ */
+public class MultiFactorAuthenticationProviderConfigurer<B extends ProviderManagerBuilder<B>>
+        extends SecurityConfigurerAdapter<AuthenticationManager, B> {
+
+    //~ Instance fields
+    // ================================================================================================
+    private AuthenticationProvider authenticationProvider;
+    private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+
+    /**
+     * Constructor
+     * @param authenticationProvider {@link AuthenticationProvider} to be delegated
+     */
+    public MultiFactorAuthenticationProviderConfigurer(AuthenticationProvider authenticationProvider) {
+        this.authenticationProvider = authenticationProvider;
+    }
+
+
+	public static MultiFactorAuthenticationProviderConfigurer multiFactorAuthenticationProvider(AuthenticationProvider authenticationProvider){
+		return new MultiFactorAuthenticationProviderConfigurer(authenticationProvider);
+	}
+
+    @Override
+    public void configure(B builder) {
+        MultiFactorAuthenticationProvider multiFactorAuthenticationProvider = new MultiFactorAuthenticationProvider(authenticationProvider, mfaTokenEvaluator);
+        multiFactorAuthenticationProvider = postProcess(multiFactorAuthenticationProvider);
+        builder.authenticationProvider(multiFactorAuthenticationProvider);
+    }
+
+    public MultiFactorAuthenticationProviderConfigurer<B> mfaTokenEvaluator(MFATokenEvaluator mfaTokenEvaluator) {
+        this.mfaTokenEvaluator = mfaTokenEvaluator;
+        return this;
+    }
+}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configuration/WebSecurityConfigurerAdapter.java
@@ -40,6 +40,8 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
+import org.springframework.security.authentication.MFATokenEvaluator;
+import org.springframework.security.authentication.MFATokenEvaluatorImpl;
 import org.springframework.security.config.annotation.ObjectPostProcessor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -113,6 +115,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 	private boolean authenticationManagerInitialized;
 	private AuthenticationManager authenticationManager;
 	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+	private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
 	private HttpSecurity http;
 	private boolean disableDefaults;
 
@@ -392,6 +395,11 @@ public abstract class WebSecurityConfigurerAdapter implements
 	}
 
 	@Autowired(required = false)
+	public void setMfaTokenEvaluator(MFATokenEvaluator mfaTokenEvaluator){
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
+	}
+
+	@Autowired(required = false)
 	public void setContentNegotationStrategy(
 			ContentNegotiationStrategy contentNegotiationStrategy) {
 		this.contentNegotiationStrategy = contentNegotiationStrategy;
@@ -420,6 +428,7 @@ public abstract class WebSecurityConfigurerAdapter implements
 		sharedObjects.put(ApplicationContext.class, context);
 		sharedObjects.put(ContentNegotiationStrategy.class, contentNegotiationStrategy);
 		sharedObjects.put(AuthenticationTrustResolver.class, trustResolver);
+		sharedObjects.put(MFATokenEvaluator.class, mfaTokenEvaluator);
 		return sharedObjects;
 	}
 

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/ExceptionHandlingConfigurer.java
@@ -17,6 +17,7 @@ package org.springframework.security.config.annotation.web.configurers;
 
 import java.util.LinkedHashMap;
 
+import org.springframework.security.authentication.MFATokenEvaluator;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -66,6 +67,8 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 		AbstractHttpConfigurer<ExceptionHandlingConfigurer<H>, H> {
 
 	private AuthenticationEntryPoint authenticationEntryPoint;
+
+	private MFATokenEvaluator mfaTokenEvaluator;
 
 	private AccessDeniedHandler accessDeniedHandler;
 
@@ -152,6 +155,18 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 	}
 
 	/**
+	 * Specifies the {@link MFATokenEvaluator} to be used
+	 *
+	 * @param mfaTokenEvaluator the {@link MFATokenEvaluator} to be used
+	 * @return the {@link ExceptionHandlingConfigurer} for further customization
+	 */
+	public ExceptionHandlingConfigurer<H> mfaTokenEvaluator(
+			MFATokenEvaluator mfaTokenEvaluator) {
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
+		return this;
+	}
+
+	/**
 	 * Sets a default {@link AuthenticationEntryPoint} to be used which prefers being
 	 * invoked for the provided {@link RequestMatcher}. If only a single default
 	 * {@link AuthenticationEntryPoint} is specified, it will be what is used for the
@@ -194,6 +209,9 @@ public final class ExceptionHandlingConfigurer<H extends HttpSecurityBuilder<H>>
 				entryPoint, getRequestCache(http));
 		AccessDeniedHandler deniedHandler = getAccessDeniedHandler(http);
 		exceptionTranslationFilter.setAccessDeniedHandler(deniedHandler);
+		if(mfaTokenEvaluator != null){
+			exceptionTranslationFilter.setMFATokenEvaluator(mfaTokenEvaluator);
+		}
 		exceptionTranslationFilter = postProcess(exceptionTranslationFilter);
 		http.addFilter(exceptionTranslationFilter);
 	}

--- a/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
+++ b/config/src/main/java/org/springframework/security/config/annotation/web/configurers/SessionManagementConfigurer.java
@@ -26,6 +26,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.GenericApplicationListenerAdapter;
 import org.springframework.context.event.SmartApplicationListener;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.MFATokenEvaluator;
 import org.springframework.security.config.annotation.web.HttpSecurityBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -424,6 +425,11 @@ public final class SessionManagementConfigurer<H extends HttpSecurityBuilder<H>>
 						.getSharedObject(AuthenticationTrustResolver.class);
 				if (trustResolver != null) {
 					httpSecurityRepository.setTrustResolver(trustResolver);
+				}
+				MFATokenEvaluator mfaTokenEvaluator = http
+						.getSharedObject(MFATokenEvaluator.class);
+				if(mfaTokenEvaluator != null){
+					httpSecurityRepository.setMFATokenEvaluator(mfaTokenEvaluator);
 				}
 				http.setSharedObject(SecurityContextRepository.class,
 						httpSecurityRepository);

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurerTests.java
@@ -1,0 +1,33 @@
+package org.springframework.security.config.annotation.authentication.configurers.mfa;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.MFATokenEvaluator;
+import org.springframework.security.authentication.MultiFactorAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.ProviderManagerBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.config.annotation.authentication.configurers.mfa.MultiFactorAuthenticationProviderConfigurer.multiFactorAuthenticationProvider;
+
+public class MultiFactorAuthenticationProviderConfigurerTests {
+
+	@Test
+	public void test(){
+		AuthenticationProvider delegatedAuthenticationProvider = mock(AuthenticationProvider.class);
+		MFATokenEvaluator mfaTokenEvaluator = mock(MFATokenEvaluator.class);
+		MultiFactorAuthenticationProviderConfigurer configurer
+				= multiFactorAuthenticationProvider(delegatedAuthenticationProvider);
+		configurer.mfaTokenEvaluator(mfaTokenEvaluator);
+		ProviderManagerBuilder providerManagerBuilder = mock(ProviderManagerBuilder.class);
+		configurer.configure(providerManagerBuilder);
+		ArgumentCaptor<AuthenticationProvider> argumentCaptor = ArgumentCaptor.forClass(AuthenticationProvider.class);
+		verify(providerManagerBuilder).authenticationProvider(argumentCaptor.capture());
+		MultiFactorAuthenticationProvider authenticationProvider = (MultiFactorAuthenticationProvider)argumentCaptor.getValue();
+
+		assertThat(authenticationProvider.getAuthenticationProvider()).isEqualTo(delegatedAuthenticationProvider);
+		assertThat(authenticationProvider.getMFATokenEvaluator()).isEqualTo(mfaTokenEvaluator);
+	}
+}

--- a/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurerTests.java
+++ b/config/src/test/java/org/springframework/security/config/annotation/authentication/configurers/mfa/MultiFactorAuthenticationProviderConfigurerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.config.annotation.authentication.configurers.mfa;
 
 import org.junit.Test;
@@ -25,7 +41,7 @@ public class MultiFactorAuthenticationProviderConfigurerTests {
 		configurer.configure(providerManagerBuilder);
 		ArgumentCaptor<AuthenticationProvider> argumentCaptor = ArgumentCaptor.forClass(AuthenticationProvider.class);
 		verify(providerManagerBuilder).authenticationProvider(argumentCaptor.capture());
-		MultiFactorAuthenticationProvider authenticationProvider = (MultiFactorAuthenticationProvider)argumentCaptor.getValue();
+		MultiFactorAuthenticationProvider authenticationProvider = (MultiFactorAuthenticationProvider) argumentCaptor.getValue();
 
 		assertThat(authenticationProvider.getAuthenticationProvider()).isEqualTo(delegatedAuthenticationProvider);
 		assertThat(authenticationProvider.getMFATokenEvaluator()).isEqualTo(mfaTokenEvaluator);

--- a/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/AuthenticationTrustResolverImpl.java
@@ -36,6 +36,8 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	private Class<? extends Authentication> anonymousClass = AnonymousAuthenticationToken.class;
 	private Class<? extends Authentication> rememberMeClass = RememberMeAuthenticationToken.class;
 
+	private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+
 	// ~ Methods
 	// ========================================================================================================
 
@@ -50,6 +52,10 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 	public boolean isAnonymous(Authentication authentication) {
 		if ((anonymousClass == null) || (authentication == null)) {
 			return false;
+		}
+
+		if(mfaTokenEvaluator != null && mfaTokenEvaluator.isMultiFactorAuthentication(authentication)){
+			return true;
 		}
 
 		return anonymousClass.isAssignableFrom(authentication.getClass());
@@ -69,5 +75,9 @@ public class AuthenticationTrustResolverImpl implements AuthenticationTrustResol
 
 	public void setRememberMeClass(Class<? extends Authentication> rememberMeClass) {
 		this.rememberMeClass = rememberMeClass;
+	}
+
+	public void setMFATokenEvaluator(MFATokenEvaluator mfaTokenEvaluator){
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
 	}
 }

--- a/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluator.java
+++ b/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluator.java
@@ -36,4 +36,16 @@ public interface MFATokenEvaluator {
 	 * in the middle of multi factor authentication process, <code>false</code> otherwise
 	 */
 	boolean isMultiFactorAuthentication(Authentication authentication);
+
+	/**
+	 * Indicates whether the principal associated with the <code>Authentication</code>
+	 * token is allowed to login with only single factor.
+	 *
+	 * @param authentication to test (may be <code>null</code> in which case the method
+	 * will always return <code>false</code>)
+	 *
+	 * @return <code>true</code> the principal associated with thepassed authentication
+	 * token is allowed to login with only single factor, <code>false</code> otherwise
+	 */
+	boolean isSingleFactorAuthenticationAllowed(Authentication authentication);
 }

--- a/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluator.java
+++ b/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Evaluates <code>Authentication</code> tokens
+ *
+ * @author Yoshikazu Nojima
+ */
+public interface MFATokenEvaluator {
+
+	/**
+	 * Indicates whether the passed <code>Authentication</code> token represents a
+	 * user in the middle of multi factor authentication process.
+     *
+	 * @param authentication to test (may be <code>null</code> in which case the method
+	 * will always return <code>false</code>)
+	 *
+	 * @return <code>true</code> the passed authentication token represented a principal
+	 * in the middle of multi factor authentication process, <code>false</code> otherwise
+	 */
+	boolean isMultiFactorAuthentication(Authentication authentication);
+}

--- a/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluatorImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluatorImpl.java
@@ -17,6 +17,7 @@
 package org.springframework.security.authentication;
 
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.MFAUserDetails;
 
 /**
  * Basic implementation of {@link MFATokenEvaluator}.
@@ -32,8 +33,7 @@ import org.springframework.security.core.Authentication;
 public class MFATokenEvaluatorImpl implements MFATokenEvaluator {
 
 	private Class<? extends Authentication> multiFactorClass = MultiFactorAuthenticationToken.class;
-
-	Class<? extends Authentication> getMultiFactorClass() { return multiFactorClass; }
+	private boolean singleFactorAuthenticationAllowed = true;
 
 	@Override
 	public boolean isMultiFactorAuthentication(Authentication authentication) {
@@ -44,6 +44,33 @@ public class MFATokenEvaluatorImpl implements MFATokenEvaluator {
 		return multiFactorClass.isAssignableFrom(authentication.getClass());
 	}
 
+	@Override
+	public boolean isSingleFactorAuthenticationAllowed(Authentication authentication) {
+		if(singleFactorAuthenticationAllowed && authentication.getPrincipal() instanceof MFAUserDetails){
+			MFAUserDetails webAuthnUserDetails = (MFAUserDetails) authentication.getPrincipal();
+			return webAuthnUserDetails.isSingleFactorAuthenticationAllowed();
+		}
+		return false;
+	}
+
+	Class<? extends Authentication> getMultiFactorClass() { return multiFactorClass; }
+
 	public void setMultiFactorClass(Class<? extends Authentication> multiFactorClass) {this.multiFactorClass = multiFactorClass; }
+
+	/**
+	 * Check if single factor authentication is allowed
+	 * @return true if single factor authentication is allowed
+	 */
+	public boolean isSingleFactorAuthenticationAllowed() {
+		return singleFactorAuthenticationAllowed;
+	}
+
+	/**
+	 * Set single factor authentication is allowed
+	 * @param singleFactorAuthenticationAllowed true if single factor authentication is allowed
+	 */
+	public void setSingleFactorAuthenticationAllowed(boolean singleFactorAuthenticationAllowed) {
+		this.singleFactorAuthenticationAllowed = singleFactorAuthenticationAllowed;
+	}
 
 }

--- a/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluatorImpl.java
+++ b/core/src/main/java/org/springframework/security/authentication/MFATokenEvaluatorImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Basic implementation of {@link MFATokenEvaluator}.
+ * <p>
+ * Makes trust decisions based on whether the passed <code>Authentication</code> is an
+ * instance of a defined class.
+ * <p>
+ * If {@link #multiFactorClass} is <code>null</code>, the
+ * corresponding method will always return <code>false</code>.
+ *
+ * @author Yoshikazu Nojima
+ */
+public class MFATokenEvaluatorImpl implements MFATokenEvaluator {
+
+	private Class<? extends Authentication> multiFactorClass = MultiFactorAuthenticationToken.class;
+
+	Class<? extends Authentication> getMultiFactorClass() { return multiFactorClass; }
+
+	@Override
+	public boolean isMultiFactorAuthentication(Authentication authentication) {
+		if ((multiFactorClass == null) || (authentication == null)) {
+			return false;
+		}
+
+		return multiFactorClass.isAssignableFrom(authentication.getClass());
+	}
+
+	public void setMultiFactorClass(Class<? extends Authentication> multiFactorClass) {this.multiFactorClass = multiFactorClass; }
+
+}

--- a/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationProvider.java
@@ -30,56 +30,56 @@ import java.util.Collections;
 public class MultiFactorAuthenticationProvider implements AuthenticationProvider {
 
 
-    // ~ Instance fields
-    // ================================================================================================
-    protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+	// ~ Instance fields
+	// ================================================================================================
+	protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
 
-    /**
-     * {@link AuthenticationProvider} to be delegated
-     */
-    private AuthenticationProvider authenticationProvider;
-    private MFATokenEvaluator mfaTokenEvaluator;
+	/**
+	 * {@link AuthenticationProvider} to be delegated
+	 */
+	private AuthenticationProvider authenticationProvider;
+	private MFATokenEvaluator mfaTokenEvaluator;
 
-    /**
-     * Constructor
-     * @param authenticationProvider {@link AuthenticationProvider} to be delegated
-     */
-    public MultiFactorAuthenticationProvider(AuthenticationProvider authenticationProvider, MFATokenEvaluator mfaTokenEvaluator) {
-        Assert.notNull(authenticationProvider, "authenticationProvider must be set");
+	/**
+	 * Constructor
+	 * @param authenticationProvider {@link AuthenticationProvider} to be delegated
+	 */
+	public MultiFactorAuthenticationProvider(AuthenticationProvider authenticationProvider, MFATokenEvaluator mfaTokenEvaluator) {
+		Assert.notNull(authenticationProvider, "authenticationProvider must be set");
 		Assert.notNull(mfaTokenEvaluator, "mfaTokenEvaluator must be set");
-        this.authenticationProvider = authenticationProvider;
-        this.mfaTokenEvaluator = mfaTokenEvaluator;
-    }
+		this.authenticationProvider = authenticationProvider;
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Authentication authenticate(Authentication authentication) {
-        if (!supports(authentication.getClass())) {
-            throw new IllegalArgumentException("Not supported AuthenticationToken " + authentication.getClass() + " was attempted");
-        }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Authentication authenticate(Authentication authentication) {
+		if (!supports(authentication.getClass())) {
+			throw new IllegalArgumentException("Not supported AuthenticationToken " + authentication.getClass() + " was attempted");
+		}
 
-        Authentication result = authenticationProvider.authenticate(authentication);
+		Authentication result = authenticationProvider.authenticate(authentication);
 
-        if(mfaTokenEvaluator.isSingleFactorAuthenticationAllowed(result)){
-            return result;
-        }
+		if(mfaTokenEvaluator.isSingleFactorAuthenticationAllowed(result)){
+			return result;
+		}
 
-        return new MultiFactorAuthenticationToken(
-                result.getPrincipal(),
-                result.getCredentials(),
-                Collections.emptyList() // result.getAuthorities() is not used as not to inherit authorities from result
-        );
-    }
+		return new MultiFactorAuthenticationToken(
+				result.getPrincipal(),
+				result.getCredentials(),
+				Collections.emptyList() // result.getAuthorities() is not used as not to inherit authorities from result
+		);
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean supports(Class<?> authentication) {
-        return authenticationProvider.supports(authentication);
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean supports(Class<?> authentication) {
+		return authenticationProvider.supports(authentication);
+	}
 
 	/**
 	 * {@link AuthenticationProvider} to be delegated

--- a/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationProvider.java
+++ b/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.SpringSecurityMessageSource;
+import org.springframework.util.Assert;
+
+import java.util.Collections;
+
+/**
+ * An {@link AuthenticationProvider} implementation for the first factor(step) of multi factor authentication.
+ * Authentication itself is delegated to another {@link AuthenticationProvider}.
+ */
+public class MultiFactorAuthenticationProvider implements AuthenticationProvider {
+
+
+    // ~ Instance fields
+    // ================================================================================================
+    protected MessageSourceAccessor messages = SpringSecurityMessageSource.getAccessor();
+
+    /**
+     * {@link AuthenticationProvider} to be delegated
+     */
+    private AuthenticationProvider authenticationProvider;
+    private MFATokenEvaluator mfaTokenEvaluator;
+
+    /**
+     * Constructor
+     * @param authenticationProvider {@link AuthenticationProvider} to be delegated
+     */
+    public MultiFactorAuthenticationProvider(AuthenticationProvider authenticationProvider, MFATokenEvaluator mfaTokenEvaluator) {
+        Assert.notNull(authenticationProvider, "authenticationProvider must be set");
+		Assert.notNull(mfaTokenEvaluator, "mfaTokenEvaluator must be set");
+        this.authenticationProvider = authenticationProvider;
+        this.mfaTokenEvaluator = mfaTokenEvaluator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Authentication authenticate(Authentication authentication) {
+        if (!supports(authentication.getClass())) {
+            throw new IllegalArgumentException("Not supported AuthenticationToken " + authentication.getClass() + " was attempted");
+        }
+
+        Authentication result = authenticationProvider.authenticate(authentication);
+
+        if(mfaTokenEvaluator.isSingleFactorAuthenticationAllowed(result)){
+            return result;
+        }
+
+        return new MultiFactorAuthenticationToken(
+                result.getPrincipal(),
+                result.getCredentials(),
+                Collections.emptyList() // result.getAuthorities() is not used as not to inherit authorities from result
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authenticationProvider.supports(authentication);
+    }
+
+	/**
+	 * {@link AuthenticationProvider} to be delegated
+	 */
+	public AuthenticationProvider getAuthenticationProvider() {
+		return authenticationProvider;
+	}
+
+	public MFATokenEvaluator getMFATokenEvaluator() {
+		return mfaTokenEvaluator;
+	}
+}

--- a/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationToken.java
+++ b/core/src/main/java/org/springframework/security/authentication/MultiFactorAuthenticationToken.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.SpringSecurityCoreVersion;
+
+import java.util.Collection;
+
+/**
+ * Represents a principal in the middle of multi factor (step) authentication
+ *
+ * @author Yoshikazu Nojima
+ */
+public class MultiFactorAuthenticationToken extends AbstractAuthenticationToken {
+
+	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
+
+	private Object principal;
+	private Object credentials;
+
+	// ~ Constructors
+	// ===================================================================================================
+	public MultiFactorAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+		super(authorities);
+		this.principal = principal;
+		this.credentials = credentials;
+		setAuthenticated(true);
+	}
+
+	// ~ Methods
+	// ========================================================================================================
+
+	@Override
+	public Object getPrincipal() {
+		return principal;
+	}
+
+	@Override
+	public Object getCredentials() {
+		return credentials;
+	}
+
+	@Override
+	public void eraseCredentials() {
+		super.eraseCredentials();
+		credentials = null;
+	}
+
+}

--- a/core/src/main/java/org/springframework/security/core/userdetails/MFAUserDetails.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/MFAUserDetails.java
@@ -1,0 +1,7 @@
+package org.springframework.security.core.userdetails;
+
+public interface MFAUserDetails extends UserDetails {
+
+	boolean isSingleFactorAuthenticationAllowed();
+
+}

--- a/core/src/main/java/org/springframework/security/core/userdetails/MFAUserDetails.java
+++ b/core/src/main/java/org/springframework/security/core/userdetails/MFAUserDetails.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.core.userdetails;
 
 public interface MFAUserDetails extends UserDetails {

--- a/core/src/test/java/org/springframework/security/authentication/MFATokenEvaluatorImplTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/MFATokenEvaluatorImplTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.junit.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.MFAUserDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MFATokenEvaluatorImplTests {
+
+	// ~ Methods
+	// ========================================================================================================
+	@Test
+	public void testCorrectOperationIsAnonymous() {
+		MFATokenEvaluatorImpl mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+		assertThat(mfaTokenEvaluator.isMultiFactorAuthentication(new MultiFactorAuthenticationToken("ignored",
+				"ignored", AuthorityUtils.createAuthorityList("ignored")))).isTrue();
+		assertThat(mfaTokenEvaluator.isMultiFactorAuthentication(new TestingAuthenticationToken("ignored",
+				"ignored", AuthorityUtils.createAuthorityList("ignored")))).isFalse();
+	}
+
+	@Test
+	public void testIsSingleFactorAuthenticationAllowedWithNonMFAUserDetailsPrincipal(){
+		MFATokenEvaluatorImpl mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+		boolean result = mfaTokenEvaluator.isSingleFactorAuthenticationAllowed(new TestingAuthenticationToken("", ""));
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	public void testIsSingleFactorAuthenticationAllowedWithMFAUserDetailsPrincipal(){
+		MFAUserDetails mfaUserDetails = mock(MFAUserDetails.class);
+		when(mfaUserDetails.isSingleFactorAuthenticationAllowed()).thenReturn(true);
+		MFATokenEvaluatorImpl mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+		boolean result = mfaTokenEvaluator.isSingleFactorAuthenticationAllowed(new TestingAuthenticationToken(mfaUserDetails, ""));
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	public void testGettersSetters() {
+		MFATokenEvaluatorImpl mfaTokenEvaluator = new MFATokenEvaluatorImpl();
+
+		assertThat(MultiFactorAuthenticationToken.class).isEqualTo(
+				mfaTokenEvaluator.getMultiFactorClass());
+		mfaTokenEvaluator.setMultiFactorClass(TestingAuthenticationToken.class);
+		assertThat(mfaTokenEvaluator.getMultiFactorClass()).isEqualTo(
+				TestingAuthenticationToken.class);
+
+		assertThat(mfaTokenEvaluator.isSingleFactorAuthenticationAllowed()).isTrue();
+		mfaTokenEvaluator.setSingleFactorAuthenticationAllowed(false);
+		assertThat(mfaTokenEvaluator.isSingleFactorAuthenticationAllowed()).isFalse();
+
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationProviderTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationProviderTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.security.authentication;
 
 

--- a/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationProviderTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationProviderTests.java
@@ -1,0 +1,70 @@
+package org.springframework.security.authentication;
+
+
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.MFAUserDetails;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MultiFactorAuthenticationProviderTests {
+
+	@Test
+	public void authenticate_with_singleFactorAuthenticationAllowedOption_false_test(){
+		AuthenticationProvider delegatedAuthenticationProvider = mock(AuthenticationProvider.class);
+		MFAUserDetails userDetails = mock(MFAUserDetails.class);
+		when(userDetails.isSingleFactorAuthenticationAllowed()).thenReturn(true);
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, Collections.emptyList());
+		authenticationToken.setDetails(userDetails);
+		when(delegatedAuthenticationProvider.supports(any())).thenReturn(true);
+		when(delegatedAuthenticationProvider.authenticate(any()))
+				.thenReturn(new UsernamePasswordAuthenticationToken(
+						"principal",
+						"credentials",
+						Collections.singletonList(new SimpleGrantedAuthority("ROLE_DUMMY"))
+				));
+
+		MultiFactorAuthenticationProvider provider = new MultiFactorAuthenticationProvider(delegatedAuthenticationProvider, new MFATokenEvaluatorImpl());
+		Authentication result = provider.authenticate(new UsernamePasswordAuthenticationToken("dummy", "dummy"));
+
+		assertThat(result).isInstanceOf(MultiFactorAuthenticationToken.class);
+		assertThat(result.getPrincipal()).isEqualTo("principal");
+		assertThat(result.getCredentials()).isEqualTo("credentials");
+		assertThat(result.getAuthorities()).isEmpty();
+
+	}
+
+	@Test
+	public void authenticate_with_singleFactorAuthenticationAllowedOption_true_test(){
+		AuthenticationProvider delegatedAuthenticationProvider = mock(AuthenticationProvider.class);
+		MFAUserDetails userDetails = mock(MFAUserDetails.class);
+		when(userDetails.isSingleFactorAuthenticationAllowed()).thenReturn(true);
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, Collections.emptyList());
+		authenticationToken.setDetails(userDetails);
+		when(delegatedAuthenticationProvider.supports(any())).thenReturn(true);
+		when(delegatedAuthenticationProvider.authenticate(any()))
+				.thenReturn(authenticationToken);
+
+		MultiFactorAuthenticationProvider provider = new MultiFactorAuthenticationProvider(delegatedAuthenticationProvider, new MFATokenEvaluatorImpl());
+		Authentication result = provider.authenticate(new UsernamePasswordAuthenticationToken("dummy", "dummy"));
+
+		assertThat(result).isInstanceOf(UsernamePasswordAuthenticationToken.class);
+		assertThat(result).isEqualTo(result);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void authenticate_with_invalid_AuthenticationToken_test(){
+		AuthenticationProvider delegatedAuthenticationProvider = mock(AuthenticationProvider.class);
+		when(delegatedAuthenticationProvider.supports(any())).thenReturn(false);
+
+		MultiFactorAuthenticationProvider provider = new MultiFactorAuthenticationProvider(delegatedAuthenticationProvider, new MFATokenEvaluatorImpl());
+		provider.authenticate(new TestingAuthenticationToken("dummy", "dummy"));
+	}
+
+}

--- a/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationTokenTests.java
+++ b/core/src/test/java/org/springframework/security/authentication/MultiFactorAuthenticationTokenTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.security.authentication;
+
+import org.junit.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultiFactorAuthenticationTokenTests {
+	// ~ Methods
+	// ========================================================================================================
+
+	@Test
+	public void authenticatedPropertyContractIsSatisfied() {
+		MultiFactorAuthenticationToken token = new MultiFactorAuthenticationToken(
+			"Test", "Password", AuthorityUtils.NO_AUTHORITIES);
+
+		// check default given we passed some GrantedAuthority[]s (well, we passed empty
+		// list)
+		assertThat(token.isAuthenticated()).isTrue();
+
+		// check explicit set to untrusted (we can safely go from trusted to untrusted,
+		// but not the reverse)
+		token.setAuthenticated(false);
+		assertThat(token.isAuthenticated()).isFalse();
+
+	}
+
+	@Test
+	public void gettersReturnCorrectData() {
+		MultiFactorAuthenticationToken token = new MultiFactorAuthenticationToken(
+				"Test", "Password",
+			AuthorityUtils.createAuthorityList("ROLE_ONE", "ROLE_TWO"));
+		assertThat(token.getPrincipal()).isEqualTo("Test");
+		assertThat(token.getCredentials()).isEqualTo("Password");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_ONE");
+		assertThat(AuthorityUtils.authorityListToSet(token.getAuthorities())).contains("ROLE_TWO");
+	}
+
+	@Test(expected = NoSuchMethodException.class)
+	public void testNoArgConstructorDoesntExist() throws Exception {
+		Class<?> clazz = UsernamePasswordAuthenticationToken.class;
+		clazz.getDeclaredConstructor((Class[]) null);
+	}
+
+}

--- a/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/access/ExceptionTranslationFilter.java
@@ -19,6 +19,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
+import org.springframework.security.authentication.MFATokenEvaluator;
+import org.springframework.security.authentication.MFATokenEvaluatorImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.SpringSecurityMessageSource;
@@ -82,6 +84,7 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 	private AccessDeniedHandler accessDeniedHandler = new AccessDeniedHandlerImpl();
 	private AuthenticationEntryPoint authenticationEntryPoint;
 	private AuthenticationTrustResolver authenticationTrustResolver = new AuthenticationTrustResolverImpl();
+	private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
 	private ThrowableAnalyzer throwableAnalyzer = new DefaultThrowableAnalyzer();
 
 	private RequestCache requestCache = new HttpSessionRequestCache();
@@ -164,6 +167,8 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 		return authenticationTrustResolver;
 	}
 
+	protected MFATokenEvaluator getMFATokenEvaluator(){ return mfaTokenEvaluator; }
+
 	private void handleSpringSecurityException(HttpServletRequest request,
 			HttpServletResponse response, FilterChain chain, RuntimeException exception)
 			throws IOException, ServletException {
@@ -205,9 +210,15 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 	protected void sendStartAuthentication(HttpServletRequest request,
 			HttpServletResponse response, FilterChain chain,
 			AuthenticationException reason) throws ServletException, IOException {
-		// SEC-112: Clear the SecurityContextHolder's Authentication, as the
-		// existing Authentication is no longer considered valid
-		SecurityContextHolder.getContext().setAuthentication(null);
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (mfaTokenEvaluator.isMultiFactorAuthentication(authentication)) {
+			// no-op if in the middle of multi step authentication
+		}
+		else {
+			// SEC-112: Clear the SecurityContextHolder's Authentication, as the
+			// existing Authentication is no longer considered valid
+			SecurityContextHolder.getContext().setAuthentication(null);
+		}
 		requestCache.saveRequest(request, response);
 		logger.debug("Calling Authentication entry point.");
 		authenticationEntryPoint.commence(request, response, reason);
@@ -223,6 +234,12 @@ public class ExceptionTranslationFilter extends GenericFilterBean {
 		Assert.notNull(authenticationTrustResolver,
 				"authenticationTrustResolver must not be null");
 		this.authenticationTrustResolver = authenticationTrustResolver;
+	}
+
+	public void setMFATokenEvaluator(
+			MFATokenEvaluator mfaTokenEvaluator){
+		Assert.notNull(mfaTokenEvaluator, "mfaTokenEvaluator must not be null");
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
 	}
 
 	public void setThrowableAnalyzer(ThrowableAnalyzer throwableAnalyzer) {

--- a/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
@@ -29,6 +29,8 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.security.authentication.AuthenticationTrustResolver;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
+import org.springframework.security.authentication.MFATokenEvaluator;
+import org.springframework.security.authentication.MFATokenEvaluatorImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.Transient;
 import org.springframework.security.core.context.SecurityContext;
@@ -99,6 +101,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 	private String springSecurityContextKey = SPRING_SECURITY_CONTEXT_KEY;
 
 	private AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+	private MFATokenEvaluator mfaTokenEvaluator = new MFATokenEvaluatorImpl();
 
 	/**
 	 * Gets the security context for the current request (if available) and returns it.
@@ -335,8 +338,8 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 		/**
 		 * Stores the supplied security context in the session (if available) and if it
 		 * has changed since it was set at the start of the request. If the
-		 * AuthenticationTrustResolver identifies the current user as anonymous, then the
-		 * context will not be stored.
+		 * AuthenticationTrustResolver identifies the current user as anonymous, but not
+		 * in the middle of multi factor authentication, then the context will not be stored.
 		 *
 		 * @param context the context object obtained from the SecurityContextHolder after
 		 * the request has been processed by the filter chain.
@@ -350,7 +353,7 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 			HttpSession httpSession = request.getSession(false);
 
 			// See SEC-776
-			if (authentication == null || trustResolver.isAnonymous(authentication)) {
+			if (authentication == null || trustResolver.isAnonymous(authentication) && !mfaTokenEvaluator.isMultiFactorAuthentication(authentication)) {
 				if (logger.isDebugEnabled()) {
 					logger.debug("SecurityContext is empty or contents are anonymous - context will not be stored in HttpSession.");
 				}
@@ -458,5 +461,17 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 	public void setTrustResolver(AuthenticationTrustResolver trustResolver) {
 		Assert.notNull(trustResolver, "trustResolver cannot be null");
 		this.trustResolver = trustResolver;
+	}
+
+	/**
+	 * Sets the {@link MFATokenEvaluator} to be used. The default is
+	 * {@link MFATokenEvaluatorImpl}.
+	 *
+	 * @param mfaTokenEvaluator the {@link MFATokenEvaluator} to use. Cannot be
+	 * null.
+	 */
+	public void setMFATokenEvaluator(MFATokenEvaluator mfaTokenEvaluator) {
+		Assert.notNull(mfaTokenEvaluator, "mfaTokenEvaluator cannot be null");
+		this.mfaTokenEvaluator = mfaTokenEvaluator;
 	}
 }

--- a/web/src/test/java/org/springframework/security/web/access/ExceptionTranslationFilterTests.java
+++ b/web/src/test/java/org/springframework/security/web/access/ExceptionTranslationFilterTests.java
@@ -43,6 +43,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.MultiFactorAuthenticationToken;
 import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -111,6 +112,40 @@ public class ExceptionTranslationFilterTests {
 		assertThat(response.getRedirectedUrl()).isEqualTo("/mycontext/login.jsp");
 		assertThat(getSavedRequestUrl(request)).isEqualTo("http://www.example.com/mycontext/secure/page.html");
 	}
+
+	@Test
+	public void testAccessDeniedWhenMultiFactorAuthentication() throws Exception {
+		// Setup our HTTP request
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/secure/page.html");
+		request.setServerPort(80);
+		request.setScheme("http");
+		request.setServerName("www.example.com");
+		request.setContextPath("/mycontext");
+		request.setRequestURI("/mycontext/secure/page.html");
+
+		// Setup the FilterChain to thrown an access denied exception
+		FilterChain fc = mock(FilterChain.class);
+		doThrow(new AccessDeniedException("")).when(fc).doFilter(
+			any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+		// Setup SecurityContextHolder, as filter needs to check if user is
+		// anonymous
+		SecurityContextHolder.getContext().setAuthentication(
+			new MultiFactorAuthenticationToken("ignored", "ignored", AuthorityUtils
+				.createAuthorityList("IGNORED")));
+
+		// Test
+		ExceptionTranslationFilter filter = new ExceptionTranslationFilter(mockEntryPoint);
+		filter.setAuthenticationTrustResolver(new AuthenticationTrustResolverImpl());
+		assertThat(filter.getAuthenticationTrustResolver()).isNotNull();
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		filter.doFilter(request, response, fc);
+		assertThat(response.getRedirectedUrl()).isEqualTo("/mycontext/login.jsp");
+		assertThat(getSavedRequestUrl(request)).isEqualTo("http://www.example.com/mycontext/secure/page.html");
+	}
+
 
 	@Test
 	public void testAccessDeniedWithRememberMe() throws Exception {


### PR DESCRIPTION
A pull request to show the diff for review, not for merge for now

-------------
This patch is to make a foundation for multi-factor(step) authentication including WebAuthn.

## Changes

\* no interface is changed

* Add `MultifactorAuthenticationToken` to represent a user in the middle of multi factor(step) authentication process
* Add `MFATokenEvaluator`/`MFATokenEvaluatorImpl` for `Authentication` type check
* Make `ExceptionTranslationFilter`, `AuthenticationTrustResolverImpl`, and `HttpSessionSecurityContextRepository` use `MFATokenEvaluator` to support multi-factor authentication
* Add `MultiFactorAuthenticationProvider`, which authenticates a user by delegating to another `AuthenticationProvider` and generates `MultifactorAuthenticationToken`
